### PR TITLE
AI routing: k-shortest paths, Actions API (POST/DELETE), cookies/timeouts, LinUCB/bandit agents

### DIFF
--- a/controller-apps/monitor_rest.py
+++ b/controller-apps/monitor_rest.py
@@ -1,102 +1,68 @@
 # controller-apps/monitor_rest.py
-# Ryu app: Simple L2 learning switch + periodic port/flow stats polling + REST API (/api/v1/health, /api/v1/stats/ports, /api/v1/stats/flows)
+for stat in ev.msg.body:
+# Skip local ports if desired (port_no == ofproto.OFPP_LOCAL)
+stats.append({
+    'timestamp': now,
+    'dpid': ev.msg.datapath.id,
+    'port_no': stat.port_no,
+    'rx_pkts': stat.rx_packets,
+    'tx_pkts': stat.tx_packets,
+    'rx_bytes': stat.rx_bytes,
+    'tx_bytes': stat.tx_bytes,
+    'rx_dropped': stat.rx_dropped,
+    'tx_dropped': stat.tx_dropped,
+    'rx_errors': stat.rx_errors,
+    'tx_errors': stat.tx_errors,
+})
+# Replace snapshot for this dpid (simple strategy)
+# Keep only last N seconds by timestamp if you want rolling window; for now, overwrite entire list
+# Group per dpid and merge into single list
+# For simplicity here, just append and trim last snapshot timestamp
+self.port_stats = [s for s in self.port_stats if s.get('dpid') != ev.msg.datapath.id]
+self.port_stats.extend(stats)
+self.last_stats_ts = now
 
 
-from collections import defaultdict
-import json
-import time
+@set_ev_cls(ofp_event.EventOFPFlowStatsReply, MAIN_DISPATCHER)
+def flow_stats_reply_handler(self, ev):
+    now = time.time()
+flows = []
+for stat in ev.msg.body:
+    match = stat.match.to_jsondict().get('OFPMatch', {}).get('oxm_fields', [])
+flows.append({
+    'timestamp': now,
+    'dpid': ev.msg.datapath.id,
+    'priority': stat.priority,
+    'table_id': stat.table_id,
+    'duration_sec': stat.duration_sec,
+    'packet_count': stat.packet_count,
+    'byte_count': stat.byte_count,
+    'match': match,
+})
+self.flow_stats = [f for f in self.flow_stats if f.get('dpid') != ev.msg.datapath.id]
+self.flow_stats.extend(flows)
+self.last_stats_ts = now
 
 
-from ryu.base import app_manager
-from ryu.controller import ofp_event
-from ryu.controller.handler import CONFIG_DISPATCHER, MAIN_DISPATCHER, DEAD_DISPATCHER, set_ev_cls
-from ryu.ofproto import ofproto_v1_3
-from ryu.lib.packet import packet, ethernet, ether_types
-from ryu.lib import hub
 
 
-from ryu.app.wsgi import WSGIApplication, ControllerBase, route
-from webob import Response
+class StatsController(ControllerBase):
+    def __init__(self, req, link, data, **config):
+    super().__init__(req, link, data, **config)
+self.app = data[API_INSTANCE_NAME]
 
 
+@route('health', '/api/v1/health', methods=['GET'])
+def health(self, req, **kwargs):
+    body = {'status': 'ok', 'last_stats_ts': self.app.last_stats_ts}
+return Response(content_type='application/json', body=json.dumps(body))
 
 
-API_INSTANCE_NAME = 'monitor_rest_api'
+@route('stats_ports', '/api/v1/stats/ports', methods=['GET'])
+def stats_ports(self, req, **kwargs):
+    return Response(content_type='application/json', body=json.dumps(self.app.port_stats))
 
 
-
-
-class SimpleSwitchMonitor(app_manager.RyuApp):
-    OFP_VERSIONS = [ofproto_v1_3.OFP_VERSION]
-
-
-_CONTEXTS = {
-    'wsgi': WSGIApplication,
-}
-
-
-def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
-self.logger.info("Starting SimpleSwitchMonitor with REST API")
-
-
-# MAC learning
-self.mac_to_port = defaultdict(dict) # dpid -> {mac: port}
-
-
-# Datapath registry
-self.datapaths = {}
-
-
-# Stats storage (latest snapshots)
-self.port_stats = [] # list of dicts
-self.flow_stats = [] # list of dicts
-self.last_stats_ts = 0.0
-
-
-# Polling
-self.monitor_interval = 5 # seconds
-self.monitor_thread = hub.spawn(self._monitor)
-
-
-# REST wiring
-wsgi = kwargs['wsgi']
-wsgi.register(StatsController, {API_INSTANCE_NAME: self})
-
-
-# ---------------------------
-# Switch connection lifecycle
-# ---------------------------
-@set_ev_cls(ofp_event.EventOFPSwitchFeatures, CONFIG_DISPATCHER)
-def switch_features_handler(self, ev):
-    dp = ev.msg.datapath
-ofp = dp.ofproto
-parser = dp.ofproto_parser
-
-
-# table-miss flow
-match = parser.OFPMatch()
-actions = [parser.OFPActionOutput(ofp.OFPP_CONTROLLER, ofp.OFPCML_NO_BUFFER)]
-inst = [parser.OFPInstructionActions(ofp.OFPIT_APPLY_ACTIONS, actions)]
-mod = parser.OFPFlowMod(datapath=dp, priority=0, match=match, instructions=inst)
-dp.send_msg(mod)
-self.logger.info("Installed table-miss on dpid=%s", dp.id)
-
-
-@set_ev_cls(ofp_event.EventOFPStateChange, [MAIN_DISPATCHER, DEAD_DISPATCHER])
-def state_change_handler(self, ev):
-    dp = ev.datapath
-if ev.state == MAIN_DISPATCHER:
-    if dp.id not in self.datapaths:
-    self.datapaths[dp.id] = dp
-self.logger.info("Datapath registered: dpid=%s", dp.id)
-elif ev.state == DEAD_DISPATCHER:
-if dp and dp.id in self.datapaths:
-    del self.datapaths[dp.id]
-self.logger.info("Datapath unregistered: dpid=%s", dp.id)
-
-
-# ---------------------------
-# L2 learning switch behavior
-# ---------------------------
-return Response(content_type='application/json', body=json.dumps(self.app.flow_stats))
+@route('stats_flows', '/api/v1/stats/flows', methods=['GET'])
+def stats_flows(self, req, **kwargs):
+    return Response(content_type='application/json', body=json.dumps(self.app.flow_stats))

--- a/controller-apps/sdn_router_rest.py
+++ b/controller-apps/sdn_router_rest.py
@@ -1,0 +1,388 @@
+# controller-apps/sdn_router_rest.py
+# Ryu app: L2 learning + Topology discovery + k-shortest paths + route install/delete + stats + REST
+# Run with: ryu-manager controller-apps/sdn_router_rest.py ryu.topology.switches --ofp-tcp-listen-port 6633
+
+from collections import defaultdict
+import hashlib
+import json
+import time
+
+from ryu.base import app_manager
+from ryu.controller import ofp_event
+from ryu.controller.handler import CONFIG_DISPATCHER, MAIN_DISPATCHER, DEAD_DISPATCHER, set_ev_cls
+from ryu.ofproto import ofproto_v1_3
+from ryu.lib.packet import packet, ethernet, ether_types
+from ryu.lib import hub
+
+# Topology
+from ryu.topology import event as topo_event
+import networkx as nx
+
+# REST
+from ryu.app.wsgi import WSGIApplication, ControllerBase, route
+from webob import Response
+
+API_INSTANCE = 'sdn_router_api'
+
+
+class SDNRouterREST(app_manager.RyuApp):
+    OFP_VERSIONS = [ofproto_v1_3.OFP_VERSION]
+    _CONTEXTS = {'wsgi': WSGIApplication}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logger.info("Starting SDNRouterREST")
+
+        # L2 learning
+        self.mac_to_port = defaultdict(dict)   # dpid -> { mac: port }
+        self.hosts = {}                        # mac -> { 'dpid': dpid, 'port': port }
+
+        # Datapaths
+        self.datapaths = {}
+
+        # Topology graph and cache
+        self.G = nx.Graph()                    # nodes: dpids; edges carry {u_port, v_port}
+        self.k_paths_cached = {}               # (src_dpid, dst_dpid, k) -> [ [dpids], ... ]
+
+        # Installed routes (for cleanup)
+        self.routes = {}                       # (src_mac, dst_mac) -> {'cookie': int, 'path': [dpids]}
+
+        # Stats
+        self.port_stats = []
+        self.flow_stats = []
+        self.last_stats_ts = 0.0
+        self.monitor_interval = 5
+        self.monitor_thread = hub.spawn(self._monitor)
+
+        # REST wiring
+        wsgi = kwargs['wsgi']
+        wsgi.register(RESTController, {API_INSTANCE: self})
+
+    # ---------- Switch lifecycle ----------
+    @set_ev_cls(ofp_event.EventOFPSwitchFeatures, CONFIG_DISPATCHER)
+    def switch_features_handler(self, ev):
+        dp = ev.msg.datapath
+        ofp = dp.ofproto
+        parser = dp.ofproto_parser
+        # table-miss
+        match = parser.OFPMatch()
+        actions = [parser.OFPActionOutput(ofp.OFPP_CONTROLLER, ofp.OFPCML_NO_BUFFER)]
+        inst = [parser.OFPInstructionActions(ofp.OFPIT_APPLY_ACTIONS, actions)]
+        dp.send_msg(parser.OFPFlowMod(datapath=dp, priority=0, match=match, instructions=inst))
+        self.logger.info("Installed table-miss on dpid=%s", dp.id)
+
+    @set_ev_cls(ofp_event.EventOFPStateChange, [MAIN_DISPATCHER, DEAD_DISPATCHER])
+    def state_change_handler(self, ev):
+        dp = ev.datapath
+        if ev.state == MAIN_DISPATCHER:
+            if dp.id not in self.datapaths:
+                self.datapaths[dp.id] = dp
+                self.G.add_node(dp.id)
+                self.logger.info("Datapath registered: %s", dp.id)
+        elif ev.state == DEAD_DISPATCHER:
+            if dp and dp.id in self.datapaths:
+                del self.datapaths[dp.id]
+                if self.G.has_node(dp.id):
+                    self.G.remove_node(dp.id)
+                self.logger.info("Datapath unregistered: %s", dp.id)
+
+    # ---------- L2 learning ----------
+    @set_ev_cls(ofp_event.EventOFPPacketIn, MAIN_DISPATCHER)
+    def packet_in_handler(self, ev):
+        msg = ev.msg
+        dp = msg.datapath
+        ofp = dp.ofproto
+        parser = dp.ofproto_parser
+        dpid = dp.id
+
+        pkt = packet.Packet(msg.data)
+        eth = pkt.get_protocols(ethernet.ethernet)[0]
+        if eth.ethertype == ether_types.ETH_TYPE_LLDP:
+            return
+        in_port = msg.match['in_port']
+        src = eth.src
+        dst = eth.dst
+
+        # learn
+        self.mac_to_port[dpid][src] = in_port
+        self.hosts[src] = {'dpid': dpid, 'port': in_port}
+
+        # forwarding decision
+        if dst in self.mac_to_port[dpid]:
+            out_port = self.mac_to_port[dpid][dst]
+        else:
+            out_port = ofp.OFPP_FLOOD
+
+        actions = [parser.OFPActionOutput(out_port)]
+        if out_port != ofp.OFPP_FLOOD:
+            match = parser.OFPMatch(in_port=in_port, eth_src=src, eth_dst=dst)
+            inst = [parser.OFPInstructionActions(ofp.OFPIT_APPLY_ACTIONS, actions)]
+            dp.send_msg(parser.OFPFlowMod(datapath=dp, priority=1, match=match, instructions=inst))
+
+        dp.send_msg(parser.OFPPacketOut(datapath=dp, buffer_id=ofp.OFP_NO_BUFFER,
+                                        in_port=in_port, actions=actions, data=msg.data))
+
+    # ---------- Topology events (from ryu.topology.switches) ----------
+    @set_ev_cls(topo_event.EventLinkAdd)
+    def link_add_handler(self, ev):
+        l = ev.link
+        u, v = l.src.dpid, l.dst.dpid
+        u_p, v_p = l.src.port_no, l.dst.port_no
+        # store both directions
+        self.G.add_edge(u, v, u_port=u_p, v_port=v_p)
+        self.G.add_edge(v, u, u_port=v_p, v_port=u_p)
+        self.k_paths_cached.clear()
+        self.logger.info("Link added: %s[%s] <-> %s[%s]", u, u_p, v, v_p)
+
+    # ---------- Periodic stats polling ----------
+    def _monitor(self):
+        while True:
+            try:
+                for dpid, dp in list(self.datapaths.items()):
+                    parser = dp.ofproto_parser
+                    dp.send_msg(parser.OFPPortStatsRequest(dp, 0, dp.ofproto.OFPP_ANY))
+                    dp.send_msg(parser.OFPFlowStatsRequest(dp))
+            except Exception as e:
+                self.logger.error("Monitor error: %s", e)
+            finally:
+                hub.sleep(self.monitor_interval)
+
+    @set_ev_cls(ofp_event.EventOFPPortStatsReply, MAIN_DISPATCHER)
+    def port_stats_reply_handler(self, ev):
+        now = time.time()
+        stats = []
+        for s in ev.msg.body:
+            stats.append({
+                'timestamp': now,
+                'dpid': ev.msg.datapath.id,
+                'port_no': s.port_no,
+                'rx_pkts': s.rx_packets,
+                'tx_pkts': s.tx_packets,
+                'rx_bytes': s.rx_bytes,
+                'tx_bytes': s.tx_bytes,
+                'rx_dropped': s.rx_dropped,
+                'tx_dropped': s.tx_dropped,
+                'rx_errors': s.rx_errors,
+                'tx_errors': s.tx_errors,
+            })
+        self.port_stats = [x for x in self.port_stats if x['dpid'] != ev.msg.datapath.id]
+        self.port_stats.extend(stats)
+        self.last_stats_ts = now
+
+    @set_ev_cls(ofp_event.EventOFPFlowStatsReply, MAIN_DISPATCHER)
+    def flow_stats_reply_handler(self, ev):
+        now = time.time()
+        flows = []
+        for s in ev.msg.body:
+            flows.append({
+                'timestamp': now,
+                'dpid': ev.msg.datapath.id,
+                'priority': s.priority,
+                'table_id': s.table_id,
+                'duration_sec': s.duration_sec,
+                'packet_count': s.packet_count,
+                'byte_count': s.byte_count,
+                'match': s.match.to_jsondict(),
+            })
+        self.flow_stats = [f for f in self.flow_stats if f['dpid'] != ev.msg.datapath.id]
+        self.flow_stats.extend(flows)
+        self.last_stats_ts = now
+
+    # ---------- Helpers ----------
+    def _k_shortest_paths(self, src_dpid, dst_dpid, k=2):
+        key = (src_dpid, dst_dpid, k)
+        if key in self.k_paths_cached:
+            return self.k_paths_cached[key]
+        if src_dpid not in self.G or dst_dpid not in self.G:
+            return []
+        try:
+            gen = nx.shortest_simple_paths(self.G, src_dpid, dst_dpid)
+            paths = []
+            for i, p in enumerate(gen):
+                paths.append(p)
+                if i + 1 >= k:
+                    break
+            self.k_paths_cached[key] = paths
+            return paths
+        except Exception:
+            return []
+
+    def _path_ports(self, path_dpids, dst_mac=None):
+        """Return list of (dpid, out_port) along path for forwarding towards dst_mac."""
+        hops = []
+        for i in range(len(path_dpids) - 1):
+            u = path_dpids[i]
+            v = path_dpids[i + 1]
+            data = self.G.get_edge_data(u, v)
+            if not data or 'u_port' not in data:
+                return []
+            hops.append({'dpid': u, 'out_port': data['u_port']})
+        # Last hop to host port if known
+        last = path_dpids[-1]
+        if dst_mac and dst_mac in self.hosts and self.hosts[dst_mac]['dpid'] == last:
+            hops.append({'dpid': last, 'out_port': self.hosts[dst_mac]['port']})
+        return hops
+
+    def _cookie_for_pair(self, src_mac, dst_mac):
+        h = hashlib.md5(f"{src_mac}->{dst_mac}".encode()).hexdigest()
+        return int(h[:16], 16)  # 64-bit cookie from first 16 hex chars
+
+    def _install_unidirectional_path(self, src_mac, dst_mac, path_dpids, priority=100):
+        """Install flows matching eth_dst=dst_mac at each hop along path (with cookie & timeouts)."""
+        cookie = self._cookie_for_pair(src_mac, dst_mac)
+        for hop in self._path_ports(path_dpids, dst_mac=dst_mac):
+            dpid = hop['dpid']
+            out_port = hop['out_port']
+            if dpid not in self.datapaths:
+                continue
+            dp = self.datapaths[dpid]
+            parser = dp.ofproto_parser
+            ofp = dp.ofproto
+            actions = [parser.OFPActionOutput(out_port)]
+            match = parser.OFPMatch(eth_dst=dst_mac)
+            inst = [parser.OFPInstructionActions(ofp.OFPIT_APPLY_ACTIONS, actions)]
+            mod = parser.OFPFlowMod(
+                datapath=dp,
+                priority=priority,
+                match=match,
+                instructions=inst,
+                cookie=cookie,
+                idle_timeout=60,   # auto-expire if inactive
+                hard_timeout=300   # safety cap
+            )
+            dp.send_msg(mod)
+        self.routes[(src_mac, dst_mac)] = {'cookie': cookie, 'path': path_dpids}
+        self.logger.info("Installed path for %s -> %s via %s cookie=0x%x",
+                         src_mac, dst_mac, path_dpids, cookie)
+
+
+class RESTController(ControllerBase):
+    def __init__(self, req, link, data, **config):
+        super().__init__(req, link, data, **config)
+        self.app: SDNRouterREST = data[API_INSTANCE]
+
+    # --- Health & Stats ---
+    @route('health', '/api/v1/health', methods=['GET'])
+    def health(self, req, **kwargs):
+        body = {'status': 'ok', 'last_stats_ts': self.app.last_stats_ts}
+        return Response(content_type='application/json', body=json.dumps(body))
+
+    @route('stats_ports', '/api/v1/stats/ports', methods=['GET'])
+    def stats_ports(self, req, **kwargs):
+        return Response(content_type='application/json', body=json.dumps(self.app.port_stats))
+
+    @route('stats_flows', '/api/v1/stats/flows', methods=['GET'])
+    def stats_flows(self, req, **kwargs):
+        return Response(content_type='application/json', body=json.dumps(self.app.flow_stats))
+
+    # --- Topology ---
+    @route('topo_nodes', '/api/v1/topology/nodes', methods=['GET'])
+    def topo_nodes(self, req, **kwargs):
+        return Response(content_type='application/json', body=json.dumps(list(self.app.G.nodes())))
+
+    @route('topo_links', '/api/v1/topology/links', methods=['GET'])
+    def topo_links(self, req, **kwargs):
+        links = []
+        for u, v, data in self.app.G.edges(data=True):
+            links.append({'src_dpid': u, 'dst_dpid': v,
+                          'src_port': data.get('u_port'), 'dst_port': data.get('v_port')})
+        return Response(content_type='application/json', body=json.dumps(links))
+
+    @route('hosts', '/api/v1/hosts', methods=['GET'])
+    def hosts(self, req, **kwargs):
+        items = [{'mac': m, 'dpid': inf['dpid'], 'port': inf['port']} for m, inf in self.app.hosts.items()]
+        return Response(content_type='application/json', body=json.dumps(items))
+
+    @route('paths', '/api/v1/paths', methods=['GET'])
+    def paths(self, req, **kwargs):
+        params = req.params
+        src_mac = params.get('src_mac')
+        dst_mac = params.get('dst_mac')
+        k = int(params.get('k', 2))
+        if not src_mac or not dst_mac:
+            return Response(status=400, content_type='application/json',
+                            body=json.dumps({'error': 'src_mac and dst_mac required'}))
+        if src_mac not in self.app.hosts or dst_mac not in self.app.hosts:
+            return Response(status=404, content_type='application/json',
+                            body=json.dumps({'error': 'hosts not yet learned'}))
+        s_dpid = self.app.hosts[src_mac]['dpid']
+        d_dpid = self.app.hosts[dst_mac]['dpid']
+        paths = self.app._k_shortest_paths(s_dpid, d_dpid, k=k)
+        out = []
+        for i, p in enumerate(paths):
+            hops = self.app._path_ports(p, dst_mac=dst_mac)
+            out.append({'path_id': i, 'dpids': p, 'hops': hops})
+        return Response(content_type='application/json', body=json.dumps(out))
+
+    # --- Actions ---
+    @route('route', '/api/v1/actions/route', methods=['POST'])
+    def route_action(self, req, **kwargs):
+        try:
+            data = json.loads(req.body)
+        except Exception:
+            return Response(status=400, content_type='application/json',
+                            body=json.dumps({'error': 'invalid json'}))
+        src_mac = data.get('src_mac')
+        dst_mac = data.get('dst_mac')
+        path = data.get('path')  # optional explicit list of dpids
+        path_id = data.get('path_id')
+        if not src_mac or not dst_mac:
+            return Response(status=400, content_type='application/json',
+                            body=json.dumps({'error': 'src_mac and dst_mac required'}))
+        if src_mac not in self.app.hosts or dst_mac not in self.app.hosts:
+            return Response(status=404, content_type='application/json',
+                            body=json.dumps({'error': 'hosts not yet learned'}))
+
+        s_dpid = self.app.hosts[src_mac]['dpid']
+        d_dpid = self.app.hosts[dst_mac]['dpid']
+        if not path:
+            k = int(data.get('k', 2))
+            paths = self.app._k_shortest_paths(s_dpid, d_dpid, k=k)
+            if not paths:
+                return Response(status=409, content_type='application/json', body=json.dumps({'error': 'no path'}))
+            idx = int(path_id) if path_id is not None else 0
+            if idx < 0 or idx >= len(paths):
+                idx = 0
+            path = paths[idx]
+
+        # Install both directions
+        self.app._install_unidirectional_path(src_mac, dst_mac, path)
+        self.app._install_unidirectional_path(dst_mac, src_mac, list(reversed(path)))
+        return Response(content_type='application/json', body=json.dumps({'status': 'applied', 'path': path}))
+
+    @route('route_list', '/api/v1/actions/list', methods=['GET'])
+    def route_list(self, req, **kwargs):
+        items = []
+        for (src, dst), meta in self.app.routes.items():
+            items.append({'src_mac': src, 'dst_mac': dst, 'cookie': meta['cookie'], 'path': meta['path']})
+        return Response(content_type='application/json', body=json.dumps(items))
+
+    @route('route_delete', '/api/v1/actions/route', methods=['DELETE'])
+    def route_delete(self, req, **kwargs):
+        params = req.params
+        src_mac = params.get('src_mac')
+        dst_mac = params.get('dst_mac')
+        if not src_mac or not dst_mac:
+            return Response(status=400, content_type='application/json',
+                            body=json.dumps({'error': 'src_mac and dst_mac required'}))
+        key = (src_mac, dst_mac)
+        if key not in self.app.routes:
+            return Response(status=404, content_type='application/json', body=json.dumps({'error': 'not found'}))
+        cookie = self.app.routes[key]['cookie']
+        mask = 0xFFFFFFFFFFFFFFFF
+        count = 0
+        for dp in self.app.datapaths.values():
+            parser = dp.ofproto_parser
+            ofp = dp.ofproto
+            mod = parser.OFPFlowMod(
+                datapath=dp,
+                command=ofp.OFPFC_DELETE,
+                out_port=ofp.OFPP_ANY,
+                out_group=ofp.OFPG_ANY,
+                cookie=cookie,
+                cookie_mask=mask
+            )
+            dp.send_msg(mod)
+            count += 1
+        del self.app.routes[key]
+        return Response(content_type='application/json', body=json.dumps({'status': 'deleted', 'affected_dpids': count}))

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,9 @@
+# Controller REST API
+Base URL: `http://<controller_ip>:8080/api/v1`
+
+## GET /health
+Returns controller liveness and last stats timestamp.
+
+### Response
+```json
+{ "status": "ok", "last_stats_ts": 1725312345.12 }

--- a/rl-agent/bandit_agent.py
+++ b/rl-agent/bandit_agent.py
@@ -1,0 +1,132 @@
+# rl-agent/bandit_agent.py
+# Epsilon-greedy contextual bandit that selects among k candidate paths for (src_mac, dst_mac).
+
+import argparse
+import json
+import time
+import requests
+import random
+from collections import defaultdict
+
+
+def get_hosts(base):
+    r = requests.get(f"{base}/hosts", timeout=3)
+    r.raise_for_status()
+    return r.json()
+
+
+def get_paths(base, src_mac, dst_mac, k=2):
+    r = requests.get(f"{base}/paths", params={'src_mac': src_mac, 'dst_mac': dst_mac, 'k': k}, timeout=5)
+    r.raise_for_status()
+    return r.json()
+
+
+def get_ports(base):
+    r = requests.get(f"{base}/stats/ports", timeout=5)
+    r.raise_for_status()
+    return r.json()
+
+
+def post_route(base, src_mac, dst_mac, path_id=None, path=None, k=2):
+    payload = {'src_mac': src_mac, 'dst_mac': dst_mac, 'k': k}
+    if path_id is not None:
+        payload['path_id'] = path_id
+    if path is not None:
+        payload['path'] = path
+    r = requests.post(f"{base}/actions/route", json=payload, timeout=5)
+    r.raise_for_status()
+    return r.json()
+
+
+def features_for_path(ports_snapshot, path_hops):
+    # index port stats by (dpid, port)
+    idx = defaultdict(dict)
+    for p in ports_snapshot:
+        idx[p['dpid']][p['port_no']] = p
+    agg = {'rx_bytes': 0, 'tx_bytes': 0, 'rx_pkts': 0, 'tx_pkts': 0, 'err': 0, 'drops': 0, 'hops': len(path_hops)}
+    for hop in path_hops:
+        p = idx.get(hop['dpid'], {}).get(hop['out_port'])
+        if p:
+            agg['rx_bytes'] += p.get('rx_bytes', 0)
+            agg['tx_bytes'] += p.get('tx_bytes', 0)
+            agg['rx_pkts']  += p.get('rx_pkts', 0)
+            agg['tx_pkts']  += p.get('tx_pkts', 0)
+            agg['err']      += p.get('rx_errors', 0) + p.get('tx_errors', 0)
+            agg['drops']    += p.get('rx_dropped', 0) + p.get('tx_dropped', 0)
+    return agg
+
+
+def score(agg_then, agg_now, dt):
+    if dt <= 0:
+        return 0.0
+    d_tx = max(0, agg_now['tx_bytes'] - agg_then['tx_bytes']) / dt
+    d_err = max(0, agg_now['err'] - agg_then['err'])
+    d_drp = max(0, agg_now['drops'] - agg_then['drops'])
+    return d_tx - 1000 * (d_err + d_drp)  # crude penalty weight
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--controller', default='127.0.0.1')
+    ap.add_argument('--port', type=int, default=8080)
+    ap.add_argument('--k', type=int, default=2)
+    ap.add_argument('--src', required=False)
+    ap.add_argument('--dst', required=False)
+    ap.add_argument('--epsilon', type=float, default=0.2)
+    ap.add_argument('--trials', type=int, default=6)
+    args = ap.parse_args()
+
+    base = f"http://{args.controller}:{args.port}/api/v1"
+    hosts = get_hosts(base)
+    if len(hosts) < 2 and (not args.src or not args.dst):
+        raise SystemExit("Need at least two learned hosts (generate traffic or ping so MACs are learned)")
+    src_mac = args.src or hosts[0]['mac']
+    dst_mac = args.dst or hosts[1]['mac']
+
+    q = defaultdict(float)  # path_id -> value
+    n = defaultdict(int)    # path_id -> plays
+
+    print("Bandit agent connected to", base, "; src=", src_mac, "dst=", dst_mac)
+
+    last_ports = get_ports(base)
+    last_t = time.time()
+
+    for t in range(args.trials):
+        paths = get_paths(base, src_mac, dst_mac, k=args.k)
+        if not paths:
+            print("No paths available yet; retrying...")
+            time.sleep(2)
+            continue
+
+        # epsilon-greedy select
+        if random.random() < args.epsilon:
+            choice = random.randrange(len(paths))
+        else:
+            best = max(range(len(paths)), key=lambda i: q[i] if i in q else 0.0)
+            choice = best
+
+        chosen = paths[choice]
+        print(f"[t={t}] choosing path_id={choice} dpids={chosen['dpids']}")
+        post_route(base, src_mac, dst_mac, path_id=choice, k=args.k)
+
+        # Observe reward after a short interval
+        time.sleep(3)
+        now_ports = get_ports(base)
+        now_t = time.time()
+
+        agg_then = features_for_path(last_ports, chosen['hops'])
+        agg_now  = features_for_path(now_ports,  chosen['hops'])
+        r = score(agg_then, agg_now, now_t - last_t)
+        print(f"  reward≈{r:.2f} (ΔtxB/s minus penalties)")
+
+        n[choice] += 1
+        q[choice] += (r - q[choice]) / n[choice]
+
+        last_ports = now_ports
+        last_t = now_t
+
+    print("Final estimates:", dict(q))
+
+
+if __name__ == '__main__':
+    main()

--- a/rl-agent/linucb_agent.py
+++ b/rl-agent/linucb_agent.py
@@ -1,0 +1,208 @@
+# rl-agent/linucb_agent.py
+# LinUCB contextual bandit for path selection with simple anomaly-aware filtering.
+
+import argparse
+import time
+import math
+import random
+import requests
+from collections import defaultdict
+
+
+def api_base(host, port):
+    return f"http://{host}:{port}/api/v1"
+
+
+def get_hosts(base):
+    r = requests.get(f"{base}/hosts", timeout=5); r.raise_for_status(); return r.json()
+
+
+def get_ports(base):
+    r = requests.get(f"{base}/stats/ports", timeout=5); r.raise_for_status(); return r.json()
+
+
+def get_paths(base, src_mac, dst_mac, k):
+    r = requests.get(f"{base}/paths", params={'src_mac': src_mac, 'dst_mac': dst_mac, 'k': k}, timeout=8)
+    r.raise_for_status(); return r.json()
+
+
+def post_route(base, src_mac, dst_mac, path_id=None, path=None, k=2):
+    payload = {'src_mac': src_mac, 'dst_mac': dst_mac, 'k': k}
+    if path_id is not None: payload['path_id'] = path_id
+    if path is not None: payload['path'] = path
+    r = requests.post(f"{base}/actions/route", json=payload, timeout=8)
+    r.raise_for_status(); return r.json()
+
+
+def index_ports(port_snapshot):
+    idx = defaultdict(dict)
+    for p in port_snapshot:
+        idx[p['dpid']][p['port_no']] = p
+    return idx
+
+
+def path_features(hops, prev_idx, cur_idx, dt):
+    """Return context vector x and anomaly score for a path.
+    x = [tx_bps, rx_bps, err_rate, drop_rate, hops, 1]
+    """
+    if dt <= 0: dt = 1e-6
+    tx_prev = rx_prev = err_prev = drop_prev = 0
+    tx_cur  = rx_cur  = err_cur  = drop_cur  = 0
+    for h in hops:
+        p0 = prev_idx.get(h['dpid'], {}).get(h['out_port'])
+        p1 = cur_idx.get(h['dpid'], {}).get(h['out_port'])
+        if p0 and p1:
+            tx_prev += p0.get('tx_bytes', 0); tx_cur += p1.get('tx_bytes', 0)
+            rx_prev += p0.get('rx_bytes', 0); rx_cur += p1.get('rx_bytes', 0)
+            err_prev += p0.get('rx_errors', 0) + p0.get('tx_errors', 0)
+            err_cur  += p1.get('rx_errors', 0) + p1.get('tx_errors', 0)
+            drop_prev += p0.get('rx_dropped', 0) + p0.get('tx_dropped', 0)
+            drop_cur  += p1.get('rx_dropped', 0) + p1.get('tx_dropped', 0)
+    tx_bps = max(0.0, (tx_cur - tx_prev) * 8.0 / dt)
+    rx_bps = max(0.0, (rx_cur - rx_prev) * 8.0 / dt)
+    err_rate = max(0.0, (err_cur - err_prev) / dt)
+    drop_rate = max(0.0, (drop_cur - drop_prev) / dt)
+    x = [tx_bps, rx_bps, err_rate, drop_rate, float(len(hops)), 1.0]
+    anomaly = (err_rate + drop_rate)
+    return x, anomaly
+
+
+class LinUCB:
+    def __init__(self, d, alpha=1.0):
+        self.d = d
+        self.alpha = alpha
+        self.A = defaultdict(lambda: self._I())     # path_id -> A (dxd)
+        self.b = defaultdict(lambda: [0.0] * d)     # path_id -> b (d)
+
+    def _I(self):
+        I = [[0.0] * self.d for _ in range(self.d)]
+        for i in range(self.d):
+            I[i][i] = 1.0
+        return I
+
+    def _Ainv(self, A):
+        # Basic Gauss-Jordan for tiny matrices; replace with numpy for scale
+        n = self.d
+        aug = [row[:] + [1.0 if i == j else 0.0 for j in range(n)] for i, row in enumerate(A)]
+        for i in range(n):
+            pivot = aug[i][i]
+            if abs(pivot) < 1e-12:
+                pivot = 1e-6
+            for j in range(2 * n):
+                aug[i][j] /= pivot
+            for k in range(n):
+                if k == i:
+                    continue
+                factor = aug[k][i]
+                for j in range(2 * n):
+                    aug[k][j] -= factor * aug[i][j]
+        return [row[n:] for row in aug]
+
+    def _matvec(self, M, v):
+        return [sum(M[i][j] * v[j] for j in range(self.d)) for i in range(self.d)]
+
+    def _quad(self, v, M):
+        tmp = self._matvec(M, v)
+        return sum(v[i] * tmp[i] for i in range(self.d))
+
+    def predict_ucb(self, path_id, x):
+        A = self.A[path_id]
+        b = self.b[path_id]
+        Ainv = self._Ainv(A)
+        theta = self._matvec(Ainv, b)
+        mu = sum(theta[i] * x[i] for i in range(self.d))
+        bonus = self.alpha * math.sqrt(max(1e-12, self._quad(x, Ainv)))
+        return mu + bonus
+
+    def update(self, path_id, x, r):
+        A = self.A[path_id]
+        for i in range(self.d):
+            for j in range(self.d):
+                A[i][j] += x[i] * x[j]
+        b = self.b[path_id]
+        for i in range(self.d):
+            b[i] += r * x[i]
+        self.A[path_id] = A
+        self.b[path_id] = b
+
+
+def reward_from_deltas(prev_idx, cur_idx, hops, dt):
+    if dt <= 0: dt = 1e-6
+    # Use Δtx_bytes/s across the path minus error/drop penalties
+    x_now, anomaly = path_features(hops, prev_idx, cur_idx, dt)
+    tx_bps = x_now[0]
+    penalty = 8000.0 * anomaly
+    return tx_bps - penalty
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--controller', default='127.0.0.1')
+    ap.add_argument('--port', type=int, default=8080)
+    ap.add_argument('--k', type=int, default=2)
+    ap.add_argument('--epsilon', type=float, default=0.1)
+    ap.add_argument('--alpha', type=float, default=1.0)
+    ap.add_argument('--trials', type=int, default=10)
+    ap.add_argument('--err_thresh', type=float, default=5.0, help='errors/sec threshold to mask paths')
+    args = ap.parse_args()
+
+    base = api_base(args.controller, args.port)
+    hosts = get_hosts(base)
+    if len(hosts) < 2:
+        raise SystemExit('Need at least 2 hosts learned (run pingall)')
+    src_mac, dst_mac = hosts[0]['mac'], hosts[1]['mac']
+
+    linucb = LinUCB(d=6, alpha=args.alpha)
+
+    prev_ports = get_ports(base)
+    prev_idx = index_ports(prev_ports)
+    prev_t = time.time()
+
+    for t in range(args.trials):
+        time.sleep(2.0)
+        cur_ports = get_ports(base)
+        cur_idx = index_ports(cur_ports)
+        now = time.time()
+        dt = now - prev_t
+
+        paths = get_paths(base, src_mac, dst_mac, k=args.k)
+        if not paths:
+            print('No paths available; retrying...')
+            prev_ports, prev_idx, prev_t = cur_ports, cur_idx, now
+            continue
+
+        # Build contexts + filter anomalous paths
+        arms = []
+        for i, p in enumerate(paths):
+            x, anomaly = path_features(p['hops'], prev_idx, cur_idx, dt)
+            if anomaly > args.err_thresh:
+                continue  # skip noisy path
+            arms.append((i, x, p))
+        if not arms:
+            arms = [(i, path_features(p['hops'], prev_idx, cur_idx, dt)[0], p) for i, p in enumerate(paths)]
+
+        # epsilon-greedy over LinUCB scores
+        if random.random() < args.epsilon:
+            choice = random.randrange(len(arms))
+        else:
+            scores = [linucb.predict_ucb(i, x) for (i, x, _) in arms]
+            choice = max(range(len(arms)), key=lambda j: scores[j])
+        path_id, x, chosen = arms[choice]
+        print(f"[t={t}] choose path_id={path_id} dpids={chosen['dpids']}")
+        post_route(base, src_mac, dst_mac, path_id=path_id, k=args.k)
+
+        # Observe reward and update
+        time.sleep(3.0)
+        new_ports = get_ports(base)
+        new_idx = index_ports(new_ports)
+        r = reward_from_deltas(prev_idx, new_idx, chosen['hops'], dt=3.0)
+        linucb.update(path_id, x, r)
+        print(f"  reward≈{r:.2f} | updated")
+
+        prev_ports, prev_idx, prev_t = new_ports, new_idx, time.time()
+
+    print("LinUCB finished.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/metrics/log_stats.py
+++ b/scripts/metrics/log_stats.py
@@ -1,5 +1,4 @@
 # scripts/metrics/log_stats.py
-# Poll controller REST endpoints periodically and write CSV for baseline metrics
 
 
 import argparse

--- a/scripts/run_ryu.sh
+++ b/scripts/run_ryu.sh
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-
 # Usage: ./scripts/run_ryu.sh [--port 6633]
 PORT=6633
 if [[ "${1:-}" == "--port" ]]; then
-PORT=${2:?port required}
+  PORT=${2:?port required}
 fi
 
-
-# Activate venv on the Pi/VM where Ryu is installed
+# Activate venv if present
 if [[ -d "$HOME/ryu-venv" ]]; then
-# shellcheck disable=SC1091
-source "$HOME/ryu-venv/bin/activate"
+  # shellcheck disable=SC1091
+  source "$HOME/ryu-venv/bin/activate"
 fi
 
-
-cd "$(dirname "$0")/.." # repo root
-exec ryu-manager controller-apps/monitor_rest.py --ofp-tcp-listen-port "$PORT"
+cd "$(dirname "$0")/.."  # repo root
+exec ryu-manager controller-apps/sdn_router_rest.py ryu.topology.switches --ofp-tcp-listen-port "$PORT"


### PR DESCRIPTION
Adds topology discovery, candidate path computation, route install/cleanup, and two agents (epsilon-greedy + LinUCB). Flow rules carry cookies and timeouts for safer lifecycle.

Changes (high level):
controller-apps/sdn_router_rest.py
Topology: GET /api/v1/topology/{nodes,links}, Hosts: GET /api/v1/hosts, Paths: GET /api/v1/paths
Actions: POST /api/v1/actions/route (bidirectional install with cookie, idle/hard timeouts)
List/Delete: GET /api/v1/actions/list, DELETE /api/v1/actions/route?src_mac&dst_mac
scripts/run_ryu.sh loads ryu.topology.switches
rl-agent/bandit_agent.py & rl-agent/linucb_agent.py
docs/api.md updates

